### PR TITLE
Update Swift syntax and remove code signing ID

### DIFF
--- a/SpeedometerHud/SpeedometerHud.xcodeproj/project.pbxproj
+++ b/SpeedometerHud/SpeedometerHud.xcodeproj/project.pbxproj
@@ -163,7 +163,9 @@
 		2EA87D281A34D0DC0000E46A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftMigration = 0720;
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Per Jansson";
 				TargetAttributes = {
 					2EA87D2F1A34D0DC0000E46A = {
@@ -284,6 +286,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -347,12 +350,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = SpeedometerHud/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.perjansson.ios.speedometerhud;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "f0da2541-ef1c-46ff-87c3-503285cf2b28";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Debug;
 		};
@@ -360,12 +365,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = SpeedometerHud/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.perjansson.ios.speedometerhud;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "f0da2541-ef1c-46ff-87c3-503285cf2b28";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Release;
 		};
@@ -383,6 +390,7 @@
 				);
 				INFOPLIST_FILE = SpeedometerHudTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.perjansson.ios.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SpeedometerHud.app/SpeedometerHud";
 			};
@@ -398,6 +406,7 @@
 				);
 				INFOPLIST_FILE = SpeedometerHudTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.perjansson.ios.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SpeedometerHud.app/SpeedometerHud";
 			};

--- a/SpeedometerHud/SpeedometerHud/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/SpeedometerHud/SpeedometerHud/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -71,6 +71,11 @@
       "idiom" : "ipad",
       "filename" : "Icon-76@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/SpeedometerHud/SpeedometerHud/Info.plist
+++ b/SpeedometerHud/SpeedometerHud/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.perjansson.ios.speedometerhud</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SpeedometerHud/SpeedometerHud/ViewController.swift
+++ b/SpeedometerHud/SpeedometerHud/ViewController.swift
@@ -81,13 +81,13 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
         locationManager.startUpdatingLocation()
     }
     
-    func locationManager(manager:CLLocationManager, didUpdateLocations locations:[AnyObject]) {
-        var locationArray = locations as NSArray
-        var location = locationArray.lastObject as? CLLocation
+    func locationManager(manager:CLLocationManager, didUpdateLocations locations:[CLLocation]) {
+        let locationArray = locations as NSArray
+        let location = locationArray.lastObject as? CLLocation
         
         if location?.speed != nil {
             var locationSpeed = location?.speed
-            var locationCourse = location?.course
+            let locationCourse = location?.course
             if (locationSpeed < 112) { // Sometimes an incorrect high speed is received
                 if (locationSpeed <= 0) {
                     locationSpeed = 0;
@@ -95,7 +95,7 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
                     hasReceivedSpeed = true;
                 }
                 
-                if locationSpeed? > 0 || self.hasReceivedSpeed! {
+                if locationSpeed > 0 || self.hasReceivedSpeed! {
                     var newSpeed : Speed
                     if locationCourse != nil {
                         newSpeed = Speed(speedInMps: locationSpeed!, course: locationCourse!);
@@ -126,7 +126,7 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
     }
     
     func speedIsValid(newSpeed : Double?) -> Bool {
-        if (newSpeed? != 0 || lastSpeed == 0 || abs(lastSpeed - newSpeed!) < 15) {
+        if (newSpeed != 0 || lastSpeed == 0 || abs(lastSpeed - newSpeed!) < 15) {
             lastSpeed = newSpeed;
             return true
         } else {
@@ -134,7 +134,7 @@ class ViewController: UIViewController, CLLocationManagerDelegate {
         }
     }
     
-    func locationManager(manager: CLLocationManager!, didFailWithError error: NSError!) {
+    func locationManager(manager: CLLocationManager, didFailWithError error: NSError) {
         locationManager.stopUpdatingLocation()
     }
     

--- a/SpeedometerHud/SpeedometerHudTests/Info.plist
+++ b/SpeedometerHud/SpeedometerHudTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.perjansson.ios.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
The reason for this PR is the code signing issue. No one can use this project with the provisioning profile ID that came attached to this project.

I also updated Swift's syntax using XCode's refactoring tool. It changed `var` to `let` and removed the optional unwrapping operator where it wasn't needed.
